### PR TITLE
Add description on address to focus on Billing address

### DIFF
--- a/spec/definitions/Customer.yaml
+++ b/spec/definitions/Customer.yaml
@@ -12,22 +12,27 @@ properties:
     example: "john@example.com"
   address1:
     type: "string"
+    description: "Billing address"
     example: "118 Main St"
   address2:
     type: "string"
+    description: "Billing address 2"
     example: "7th Floor"
   city:
     type: "string"
+    description: "Billing city"
     example: "New York"
   state:
     type: "string"
+    description: "Billing state"
     example: "New York"
   postcode:
     type: "string"
+    description: "Billing postcode"
     example: "10001"
   country:
     type: "string"
-    description: "Format [ISO 3166-1 Alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)"
+    description: "Billing country. Format [ISO 3166-1 Alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)"
     example: "US"
 required:
   - "first_name"


### PR DESCRIPTION
Why?
* We are not specifying the type of customer address. It can be "billing" or "shipping" which is used for very different purposes

What?
* Add descriptions refering to this fields for billing address (which is what matters for our Compliance team)